### PR TITLE
feat(credentials): Make Azure AD OAuth2 URLs editable to support private Azure AD instances.

### DIFF
--- a/credentials/PowerBiApiOAuth2Api.credentials.ts
+++ b/credentials/PowerBiApiOAuth2Api.credentials.ts
@@ -16,13 +16,13 @@ export class PowerBiApiOAuth2Api implements ICredentialType {
         {
             displayName: 'Authorization URL',
             name: 'authUrl',
-            type: 'hidden',
+            type: 'string',
             default: 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize',
         },
         {
             displayName: 'Access Token URL',
             name: 'accessTokenUrl',
-            type: 'hidden',
+            type: 'string',
             default: 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
         },
         {


### PR DESCRIPTION
Change the type of the Authorization URL and Access Token URL in credentials from "hidden" to "string".